### PR TITLE
release: 1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.3] - 2020-07-27
+
+### Changed
+
+-   update ledgerhq deps ([#42])
+
+### Security
+
+-   bump codecov from 3.6.5 to 3.7.1 ([#41])
+-   bump lodash from 4.17.15 to 4.17.19 ([#40])
+
 ## [1.1.2] - 2020-06-09
 
 ### Added
@@ -78,4 +89,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [#30]: https://github.com/ArkEcosystem/ledger-transport/pull/33
 [1.1.0]: https://github.com/ArkEcosystem/ledger-transport/compare/cf7d9a6679b4db74c07c50155549882f1737b87e...4ead4c126f6b92ad7539c9c23bfa52651e82c577
 [1.1.1]: https://github.com/ArkEcosystem/ledger-transport/compare/4ead4c126f6b92ad7539c9c23bfa52651e82c577...518e599166afc96cb4f2088158ad316d810d7b77
-[1.1.2]: https://github.com/ArkEcosystem/ledger-transport/compare/518e599166afc96cb4f2088158ad316d810d7b77...1.1.2
+[1.1.2]: https://github.com/ArkEcosystem/ledger-transport/compare/518e599166afc96cb4f2088158ad316d810d7b77...55809fe49e6d76961303c8162e29619a8ab921d8
+[#40]: https://github.com/ArkEcosystem/ledger-transport/pull/40
+[#41]: https://github.com/ArkEcosystem/ledger-transport/pull/41
+[#42]: https://github.com/ArkEcosystem/ledger-transport/pull/42
+[1.1.3]: https://github.com/ArkEcosystem/ledger-transport/compare/55809fe49e6d76961303c8162e29619a8ab921d8...1.1.3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@arkecosystem/ledger-transport",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "description": "A Ledger Hardware Wallet Interface in TypeScript for the ARK Blockchain.",
     "license": "MIT",
     "contributors": [

--- a/package.json
+++ b/package.json
@@ -47,8 +47,7 @@
         "prepublishOnly": "yarn build"
     },
     "devDependencies": {
-        "@ledgerhq/hw-transport": "^5.7.0",
-        "@ledgerhq/hw-transport-mocker": "^5.12.0",
+        "@ledgerhq/hw-transport-mocker": "^5.19.1",
         "@sindresorhus/tsconfig": "sindresorhus/tsconfig",
         "@types/jest": "^25.2.1",
         "@types/node": "^13.5.0",
@@ -71,6 +70,7 @@
         "typescript-eslint": "^0.0.1-alpha.0"
     },
     "dependencies": {
-        "@ledgerhq/errors": "^5.13.1"
+        "@ledgerhq/errors": "^5.19.1",
+        "@ledgerhq/hw-transport": "^5.19.1"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3257,9 +3257,9 @@ lodash.sortby@^4.7.0:
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
 lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+  version "4.17.19"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
+  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
 log-symbols@^3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -491,41 +491,41 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
-"@ledgerhq/devices@^5.13.1":
-  version "5.13.1"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/devices/-/devices-5.13.1.tgz#1d65fcbcc470874968e2e74f7e87e3f350c4b332"
-  integrity sha512-E3zgmA51+esMkczM9xLddVz0myXTauJaT5g4bbwGxxeHQyHyvaJNyOhMmcuxZN/aa/lfRmxYGthcN2JBUPju5A==
+"@ledgerhq/devices@^5.19.1":
+  version "5.19.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/devices/-/devices-5.19.1.tgz#d155916d38eaf09d721faa0267d5cc043190aa95"
+  integrity sha512-i7PU0fsOkV5JDuD+57AliJ0FIBPgSSKbH8MbTOpYRhyAWfC7e7Em0SVl2B2JbzxjJ6/ltTq2+7zjLewu/ie5AA==
   dependencies:
-    "@ledgerhq/errors" "^5.13.1"
-    "@ledgerhq/logs" "^5.13.1"
-    rxjs "^6.5.5"
+    "@ledgerhq/errors" "^5.19.1"
+    "@ledgerhq/logs" "^5.19.1"
+    rxjs "^6.6.0"
 
-"@ledgerhq/errors@^5.13.1":
-  version "5.13.1"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-5.13.1.tgz#1df73a8084609888fabcefbdb9edfd4c11ab3a22"
-  integrity sha512-IuEw9a70K3C3AZV4yVGk75HlwmKmJaR6EjMIxBAupiCw0G6rBP0d62MA1Vx4dg082LKKNXKafWcDstLG4ySpBA==
+"@ledgerhq/errors@^5.19.1":
+  version "5.19.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-5.19.1.tgz#3d25cc0ee92feee35415236c741ef668a106e275"
+  integrity sha512-9v4ishxc2doiR06E/87uJdT7LjnSpnWPftDaBXBm/6KEgjPGtGBCcRW3fkmQTWNE115e6TG9JYRiVRPuqs6GHg==
 
-"@ledgerhq/hw-transport-mocker@^5.12.0":
-  version "5.13.1"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-mocker/-/hw-transport-mocker-5.13.1.tgz#85b5422d766362e8c2dabe335021cd188f36a05b"
-  integrity sha512-Eda6tBIaglpPEDIK8q7s5CH4+Y5CeExXfeQy70vIi1JCP/r9BDn/kpi/VJwGFykxmCWxv0CBvlccXA/BOd7oqQ==
+"@ledgerhq/hw-transport-mocker@^5.19.1":
+  version "5.19.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-mocker/-/hw-transport-mocker-5.19.1.tgz#8ec14f8558b735b3a07669e7be029dbb7d65f77b"
+  integrity sha512-MeNloEyrNLq3ca7gNC1ijO7RzIwvaQ/1wG7m5Nu/1Xhxm4qEcu3OsLnNkpnHclF+fGYRkl/oFb0mV77VMjPXaQ==
   dependencies:
-    "@ledgerhq/hw-transport" "^5.13.1"
-    "@ledgerhq/logs" "^5.13.1"
+    "@ledgerhq/hw-transport" "^5.19.1"
+    "@ledgerhq/logs" "^5.19.1"
 
-"@ledgerhq/hw-transport@^5.13.1", "@ledgerhq/hw-transport@^5.7.0":
-  version "5.13.1"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-5.13.1.tgz#b0fb8208b0fb383f3984c1af26a9b9e7a3ad3d75"
-  integrity sha512-TQJJY10ZoToYjaGK+u9wud0W2dK+6TBA753FGlHgptydSaRmep0uc4A2TxOLPexdVlbHXmkMa1skd3w4ZrKKdA==
+"@ledgerhq/hw-transport@^5.19.1":
+  version "5.19.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-5.19.1.tgz#8dc58b4348577e582c11aadd399abeacb78f9193"
+  integrity sha512-Ec2I6jI1jrxkqaCdyEXVwra/3gOnzwWhv3eJTIqzT1wKrUNeG6B27cau0ETiLdgOtbRQ8fltonCo8Od3MC2h+Q==
   dependencies:
-    "@ledgerhq/devices" "^5.13.1"
-    "@ledgerhq/errors" "^5.13.1"
+    "@ledgerhq/devices" "^5.19.1"
+    "@ledgerhq/errors" "^5.19.1"
     events "^3.1.0"
 
-"@ledgerhq/logs@^5.13.1":
-  version "5.13.1"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-5.13.1.tgz#80a13031c9e0a9b874b96b6636f3f6df603ec1b2"
-  integrity sha512-ag2wX5VcAqPMKooCn/S6kKblVlsn74ixtagpwR+6GdFqYa/bspH8mWw+zwcdzSwa/wbOQRuY75zH52qBonfXBA==
+"@ledgerhq/logs@^5.19.1":
+  version "5.19.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-5.19.1.tgz#c3df2b307331ccd373abc78b8ccea02377049256"
+  integrity sha512-nz33IoR3dG3DtJ46AyfLfpdMjGMkwmi21H49wcqVfNAteEe74fzO4cw9fcGMb4ENspYYtmB4LWTSp4gVPRglcg==
 
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
@@ -4080,10 +4080,17 @@ run-parallel@^1.1.9:
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.9.tgz#c9dd3a7cf9f4b2c4b6244e173a6ed866e61dd679"
   integrity sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==
 
-rxjs@^6.3.3, rxjs@^6.5.3, rxjs@^6.5.5:
+rxjs@^6.3.3, rxjs@^6.5.3:
   version "6.5.5"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.5.tgz#c5c884e3094c8cfee31bf27eb87e54ccfc87f9ec"
   integrity sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==
+  dependencies:
+    tslib "^1.9.0"
+
+rxjs@^6.6.0:
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.0.tgz#af2901eedf02e3a83ffa7f886240ff9018bbec84"
+  integrity sha512-3HMA8z/Oz61DUHe+SdOiQyzIf4tOx5oQHmMir7IZEu6TMqCLHT4LRcmNaUS0NwOz8VLvmmBduMsoaUvMaIiqzg==
   dependencies:
     tslib "^1.9.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1260,9 +1260,9 @@ co@^4.6.0:
   integrity sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
 
 codecov@^3.6.5:
-  version "3.6.5"
-  resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.6.5.tgz#d73ce62e8a021f5249f54b073e6f2d6a513f172a"
-  integrity sha512-v48WuDMUug6JXwmmfsMzhCHRnhUf8O3duqXvltaYJKrO1OekZWpB/eH6iIoaxMl8Qli0+u3OxptdsBOYiD7VAQ==
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.7.1.tgz#434cb8d55f18ef01672e5739d3d266696bebc202"
+  integrity sha512-JHWxyPTkMLLJn9SmKJnwAnvY09kg2Os2+Ux+GG7LwZ9g8gzDDISpIN5wAsH1UBaafA/yGcd3KofMaorE8qd6Lw==
   dependencies:
     argv "0.0.2"
     ignore-walk "3.0.3"


### PR DESCRIPTION

## Summary

## [1.1.3]

### Changed

-   update ledgerhq deps ([#42])

### Security

-   bump codecov from 3.6.5 to 3.7.1 ([#41])  
    [CVE-2020-8203](https://github.com/advisories/GHSA-p6mc-m468-83gw)

-   bump lodash from 4.17.15 to 4.17.19 ([#40])  
   [GHSA-xp63-6vf5-xf3v](https://github.com/advisories/GHSA-xp63-6vf5-xf3v)

## Checklist

- [x] Ready to be merged
