### PR TITLE
chore: add ext key support

### DIFF
--- a/__tests__/__fixtures__/transport-fixtures.ts
+++ b/__tests__/__fixtures__/transport-fixtures.ts
@@ -7,6 +7,10 @@ export const Fixtures = {
         result: "2.0.1",
     },
     bip44: {
+        extended: {
+            path: "44'/111'/0'",
+            result: Buffer.from("038000002c8000006f80000000", "hex"),
+        },
         path: {
             invalid: "44'/11x'/0'/0/0",
             valid: "44'/111'/0'/0/0",

--- a/__tests__/__fixtures__/transport-fixtures.ts
+++ b/__tests__/__fixtures__/transport-fixtures.ts
@@ -36,6 +36,14 @@ export const Fixtures = {
         invalid: "tëst",
     },
     publicKey: {
+        extended: {
+            record: `
+            => e002000115058000002c8000006f800000000000000000000000
+            <= 210214b1cd3dd4c955e269628127fa27d5bccc6bbfcf23dfa3add94b9292f355a84f8d6fcfb5d4a9dbfc1084915c390e86e9d66eb511a9046dece25a6a6b9fc899049000
+            `,
+            result:
+                "0214b1cd3dd4c955e269628127fa27d5bccc6bbfcf23dfa3add94b9292f355a84f8d6fcfb5d4a9dbfc1084915c390e86e9d66eb511a9046dece25a6a6b9fc89904",
+        },
         record: `
         => e002000015058000002c8000006f800000000000000000000000
         <= 210214b1cd3dd4c955e269628127fa27d5bccc6bbfcf23dfa3add94b9292f355a84f9000

--- a/__tests__/ark.test.ts
+++ b/__tests__/ark.test.ts
@@ -36,6 +36,15 @@ describe("ARKTransport", () => {
         });
     });
 
+    describe("getExtPublicKey", () => {
+        it("should pass with an extended account publicKey and chaincode", async () => {
+            const ark = await TransportMock.getARKTransport(RecordStore.fromString(Fixtures.publicKey.extended.record));
+            await expect(ark.getExtPublicKey(Fixtures.bip44.path.valid)).resolves.toEqual(
+                Fixtures.publicKey.extended.result,
+            );
+        });
+    });
+
     describe("signMessageWithSchnorr", () => {
         it("should pass with a schnorr signature", async () => {
             const ark = await TransportMock.getARKTransport(RecordStore.fromString(Fixtures.message.schnorr.record));

--- a/__tests__/bip44.test.ts
+++ b/__tests__/bip44.test.ts
@@ -5,6 +5,11 @@ import * as Bip44 from "../src/bip44";
 import * as TransportErrors from "../src/errors";
 
 describe("Bip44", () => {
+    test("should pass with an extended account Bip44 path", () => {
+        const accountPath = Bip44.Path.fromString(Fixtures.bip44.extended.path).toBytes();
+        expect(accountPath).toEqual(Fixtures.bip44.extended.result);
+    });
+
     test("should pass with a prefixed Bip44 path", () => {
         const prefixedPath = Bip44.Path.fromString(Fixtures.bip44.prefixed.path).toBytes();
         expect(prefixedPath).toEqual(Fixtures.bip44.prefixed.result);

--- a/src/ark.ts
+++ b/src/ark.ts
@@ -19,12 +19,7 @@ export class ARK implements LedgerTransport {
         this.transport = transport;
         this.transport.decorateAppAPIMethods(
             this,
-            [
-                "getVersion",
-                "getPublicKey",
-                "signMessageWithSchnorr",
-                "signTransactionWithSchnorr",
-            ],
+            ["getVersion", "getPublicKey", "getExtPublicKey", "signMessageWithSchnorr", "signTransactionWithSchnorr"],
             "w0w",
         );
     }
@@ -57,6 +52,27 @@ export class ARK implements LedgerTransport {
             Apdu.Flag.INS_GET_PUBLIC_KEY,
             Apdu.Flag.P1_NON_CONFIRM,
             Apdu.Flag.P2_NO_CHAINCODE,
+            Bip44.Path.fromString(path).toBytes(),
+        ).send(this.transport);
+
+        return response.slice(1, response.length).toString("hex");
+    }
+
+    /**
+     * Get the Extended PublicKey from a Ledger Device using a Bip44 path-string.
+     *
+     * Used to derive a 'hardened' account key (eg 44'/111'/0'").
+     * Hex result is a 33-byte compressed publicKey prepending a 32-byte chainCode.
+     *
+     * @param {string} path bip44 path as a string
+     * @returns {Promise<string>} device extended publicKey & chaincode
+     */
+    public async getExtPublicKey(path: string): Promise<string> {
+        const response = await new Apdu.Builder(
+            Apdu.Flag.CLA,
+            Apdu.Flag.INS_GET_PUBLIC_KEY,
+            Apdu.Flag.P1_NON_CONFIRM,
+            Apdu.Flag.P2_CHAINCODE,
             Bip44.Path.fromString(path).toBytes(),
         ).send(this.transport);
 

--- a/src/bip44.ts
+++ b/src/bip44.ts
@@ -15,11 +15,12 @@ import * as TransportErrors from "./errors";
  * https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
  *
  * @example const bip44Bytes = Bip44Path.fromString("44'/111'/0'/0/0").toBytes()
+ * @example const bip44Bytes = Bip44Path.fromString("44'/111'/0'").toBytes()
  * @example const bip44Bytes = Bip44Path.fromString("m/44'/111'/0'/0/0").toBytes()
  */
 export class Bip44Path {
     private static readonly HARDENING: number = 0x80000000;
-    private static readonly REGEXP_VALID_BIP44: string = "^((m/)?(44'?)){1}(/[0-9]+'?){2}(/[0-9]+){2}$";
+    private static readonly REGEXP_VALID_BIP44: string = "^((m/)?(44'?))(/[0-9]+'?){2}((/[0-9]+){2})?$";
     private _elements: number[] = [];
 
     /**


### PR DESCRIPTION

## Summary

Add extended key derivation support.

- chore(bip44): add ext key support (4e4f280)
   - modify regexp, allow optional change & address elements
   - update test fixture
   - update unit test
- chore(ark.ts): add ext key support (6bd1d8c)
   - add `getExtPublicKey` method
   - update test fixture
   - update unit test
  
## Checklist

- [x] Tests _(if necessary)_
- [x] Ready to be merged
